### PR TITLE
refactor(usecase): internalize FX conversion behind PriceConverter

### DIFF
--- a/shopally-backend/pkg/usecase/fx_converter.go
+++ b/shopally-backend/pkg/usecase/fx_converter.go
@@ -1,0 +1,21 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/shopally-ai/pkg/domain"
+)
+
+// PriceConverter converts prices using the FX client.
+type PriceConverter struct {
+	FX domain.IFXClient
+}
+
+// USDToETB converts a USD amount to ETB and returns both the converted amount and the rate used.
+func (c PriceConverter) USDToETB(ctx context.Context, usd float64) (etb float64, rate float64, err error) {
+	rate, err = c.FX.GetRate(ctx, "USD", "ETB")
+	if err != nil {
+		return 0, 0, err
+	}
+	return usd * rate, rate, nil
+}

--- a/shopally-backend/pkg/usecase/fx_converter_test.go
+++ b/shopally-backend/pkg/usecase/fx_converter_test.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shopally-ai/internal/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type PriceConverterSuite struct {
+	suite.Suite
+	ctx context.Context
+	fx  *mocks.IFXClient
+	pc  PriceConverter
+}
+
+func (s *PriceConverterSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.fx = mocks.NewIFXClient(s.T())
+	s.pc = PriceConverter{FX: s.fx}
+}
+
+func (s *PriceConverterSuite) TestUSDToETB_Success() {
+	s.fx.On("GetRate", s.ctx, "USD", "ETB").Return(56.5, nil).Once()
+	etb, rate, err := s.pc.USDToETB(s.ctx, 10.0)
+	s.Require().NoError(err)
+	s.InDelta(56.5, rate, 1e-9)
+	s.InDelta(565.0, etb, 1e-9)
+}
+
+func (s *PriceConverterSuite) TestUSDToETB_Error() {
+	s.fx.On("GetRate", s.ctx, "USD", "ETB").Return(0.0, errors.New("fx down")).Once()
+	etb, rate, err := s.pc.USDToETB(s.ctx, 5.0)
+	s.Error(err)
+	s.Equal(0.0, rate)
+	s.Equal(0.0, etb)
+}
+
+func TestPriceConverterSuite(t *testing.T) { suite.Run(t, new(PriceConverterSuite)) }


### PR DESCRIPTION
This pull request introduces a new `PriceConverter` use case for converting USD to ETB using an FX client, along with comprehensive unit tests to validate its functionality and error handling.

New USD to ETB conversion logic:

* Added the `PriceConverter` struct in `fx_converter.go`, which uses an injected `IFXClient` to fetch FX rates and convert USD amounts to ETB.
* Implemented the `USDToETB` method to perform the conversion and return both the converted amount and the rate used, including error propagation if the FX client fails.

Testing and validation:

* Introduced `fx_converter_test.go` with a test suite using a mocked `IFXClient` to verify both successful conversion and error scenarios for the `USDToETB` method.